### PR TITLE
make tsparticles let through mouse

### DIFF
--- a/newPortfolio/src/style.css
+++ b/newPortfolio/src/style.css
@@ -252,6 +252,7 @@ button:focus {
   background-size: cover !important;
   width: 100%;
   height: 100%;
+  pointer-events: none; 
 }
 
 .home-header {


### PR DESCRIPTION
The tsparticle overlay is in the way of mouse interactions. 

e.g. clicking the github icon at the bottom of the page. 

Adding "pointer-event: none;" in the #tsparticles css  rule should make the browser show the pointer cursor and allow clicks on github and linkedIn buttons. 